### PR TITLE
Fix: Resolve sidebar overlapping content

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -15,8 +15,8 @@ body {
 }
 
 .container { /* Ensure this class is used in layouts for content wrapping */
-  max-width: 1100px;
-  margin: 0 auto;
+  /* max-width: 1100px; */
+  /* margin: 0 auto; */
   padding: 0 20px; /* Add some horizontal padding */
 }
 


### PR DESCRIPTION
The sidebar was overlapping the main content area on pages. This was caused by a CSS conflict:
- The Hyde theme (`hyde.css`) applies `margin-left` to the `.content` class to make space for the fixed sidebar.
- Custom styles in `assets/css/style.css` applied `margin: 0 auto;` to the `.container` class.

Since the content div in `_layouts/default.html` uses both classes
 (`<div class="content container">`), the `margin: 0 auto;` from
`.container` was overriding Hyde's `margin-left`, causing the content to not shift over and thus be obscured by the sidebar.

This commit resolves the issue by commenting out `margin: 0 auto;` and `max-width: 1100px;` from the `.container` definition in `assets/css/style.css`. This allows Hyde's theme styles to correctly control the content positioning and width relative to the sidebar.